### PR TITLE
Implement redirection in worker

### DIFF
--- a/DATSI/SSDD/map.2025/worker_node/worker.c
+++ b/DATSI/SSDD/map.2025/worker_node/worker.c
@@ -126,6 +126,20 @@ int main(int argc, char *argv[]) {
             /* proceso hijo: ejecuta el programa */
             close(s);
             close(s_conec);
+            int fd_in = open(input, O_RDONLY);
+            if (fd_in >= 0) {
+                dup2(fd_in, STDIN_FILENO);
+                close(fd_in);
+            }
+            const char *fname = strrchr(input, '/');
+            fname = fname ? fname + 1 : input;
+            char newfile[strlen(output) + 1 + strlen(fname) + 6];
+            sprintf(newfile, "%s/%s-00000", output, fname);
+            int fd_out = open(newfile, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+            if (fd_out >= 0) {
+                dup2(fd_out, STDOUT_FILENO);
+                close(fd_out);
+            }
             execlp(program, program, (char *)NULL);
             perror("error en execlp");
             _exit(1);


### PR DESCRIPTION
## Summary
- redirect worker's stdin/out to the input file and generated output file
- create output file using basename of input and suffix `-00000`

## Testing
- `make -C DATSI/SSDD/map.2025/worker_node clean && make`
- `make -C DATSI/SSDD/map.2025/client_node clean && make`
- run manager and worker; execute map with `swap_case.py` and verify output

------
https://chatgpt.com/codex/tasks/task_e_6842dce21a3083239544dfa8cdc0a14f