### PR TITLE
Implement multi-worker dispatch

### DIFF
--- a/DATSI/SSDD/map.2025/client_node/map.c
+++ b/DATSI/SSDD/map.2025/client_node/map.c
@@ -57,8 +57,24 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "programa inválido\n"); return 1;
     }
 
-    int s = create_socket_cln_by_name(argv[1], argv[2]);
-    if (s < 0) return 1;
+    int sm = create_socket_cln_by_name(argv[1], argv[2]);
+    if (sm < 0) return 1;
+
+    int opcode = htonl(MSG_TYPE_WORKER_RESERVE);
+    int nworkers_net = htonl(nworkers);
+    struct iovec rqv[2];
+    rqv[0].iov_base = &opcode; rqv[0].iov_len = sizeof(int);
+    rqv[1].iov_base = &nworkers_net; rqv[1].iov_len = sizeof(int);
+    if (writev(sm, rqv, 2) < 0) { perror("error en writev"); close(sm); return 1; }
+
+    unsigned int ips[nworkers];
+    unsigned short ports[nworkers];
+    for (int i=0; i<nworkers; i++) {
+        if (recv(sm, &ips[i], sizeof(unsigned int), MSG_WAITALL)!=sizeof(unsigned int) ||
+            recv(sm, &ports[i], sizeof(unsigned short), MSG_WAITALL)!=sizeof(unsigned short)) {
+            perror("error en recv"); close(sm); return 1; }
+    }
+    close(sm);
 
     int input_len = strlen(input);
     int output_len = strlen(output);
@@ -70,37 +86,38 @@ int main(int argc, char *argv[]) {
     int program_len_net = htonl(program_len);
 
     size_t nblocks = (input_size + blocksize - 1) / blocksize;
-    int nblocks_net = htonl(nblocks);
 
-    struct iovec hdr[8];
-    int h = 0;
-    hdr[h].iov_base = &input_len_net; hdr[h++].iov_len = sizeof(int);
-    hdr[h].iov_base = input; hdr[h++].iov_len = input_len;
-    hdr[h].iov_base = &output_len_net; hdr[h++].iov_len = sizeof(int);
-    hdr[h].iov_base = output; hdr[h++].iov_len = output_len;
-    hdr[h].iov_base = &program_len_net; hdr[h++].iov_len = sizeof(int);
-    hdr[h].iov_base = program; hdr[h++].iov_len = program_len;
-    hdr[h].iov_base = &blocksize_net; hdr[h++].iov_len = sizeof(int);
-    hdr[h].iov_base = &nblocks_net; hdr[h++].iov_len = sizeof(int);
+    int sockets[nblocks];
 
-    if (writev(s, hdr, h) < 0) {
-        perror("error en writev"); close(s); return 1;
+    for (int i = 0; i < (int)nblocks; i++) {
+        sockets[i] = create_socket_cln_by_addr(ips[i], ports[i]);
+        if (sockets[i] < 0) { perror("error connect worker"); return 1; }
+
+        int nblocks_net = htonl(1);
+        struct iovec hdr[8];
+        int h = 0;
+        hdr[h].iov_base = &input_len_net; hdr[h++].iov_len = sizeof(int);
+        hdr[h].iov_base = input; hdr[h++].iov_len = input_len;
+        hdr[h].iov_base = &output_len_net; hdr[h++].iov_len = sizeof(int);
+        hdr[h].iov_base = output; hdr[h++].iov_len = output_len;
+        hdr[h].iov_base = &program_len_net; hdr[h++].iov_len = sizeof(int);
+        hdr[h].iov_base = program; hdr[h++].iov_len = program_len;
+        hdr[h].iov_base = &blocksize_net; hdr[h++].iov_len = sizeof(int);
+        hdr[h].iov_base = &nblocks_net; hdr[h++].iov_len = sizeof(int);
+        if (writev(sockets[i], hdr, h) < 0) { perror("error en writev"); return 1; }
+
+        int block_net = htonl(i);
+        if (write(sockets[i], &block_net, sizeof(int)) != sizeof(int)) {
+            perror("error en write"); return 1; }
     }
 
     for (int i = 0; i < (int)nblocks; i++) {
-        int block_net = htonl(i);
-        if (write(s, &block_net, sizeof(int)) != sizeof(int)) {
-            perror("error en write"); close(s); return 1;
-        }
         int ack;
-        int res = recv(s, &ack, sizeof(int), MSG_WAITALL);
-        if (res != sizeof(int)) {
-            if (res != 0) perror("error en recv");
-            close(s); return 1;
-        }
+        int res = recv(sockets[i], &ack, sizeof(int), MSG_WAITALL);
+        if (res != sizeof(int)) { if (res!=0) perror("error en recv"); }
+        close(sockets[i]);
     }
 
-    close(s);
     return 0;
 }
 

--- a/DATSI/SSDD/map.2025/manager_node/manager.c
+++ b/DATSI/SSDD/map.2025/manager_node/manager.c
@@ -18,7 +18,6 @@ typedef struct thread_info {
 static void *connection_handler(void *arg){
     thread_info *th = arg;
     int opcode, res;
-    unsigned short port;
 
     if ((res=recv(th->socket, &opcode, sizeof(int), MSG_WAITALL))!=sizeof(int)){
         if (res!=0) perror("error en recv");
@@ -27,18 +26,44 @@ static void *connection_handler(void *arg){
         return NULL;
     }
     opcode = ntohl(opcode);
-    if ((res=recv(th->socket, &port, sizeof(unsigned short), MSG_WAITALL))!=sizeof(unsigned short)){
-        if (res!=0) perror("error en recv");
-        close(th->socket);
-        free(th);
-        return NULL;
-    }
-    if (opcode == 1) {
+    if (opcode == MSG_TYPE_WORKER_REGISTER) {
+        unsigned short port;
+        if ((res=recv(th->socket, &port, sizeof(unsigned short), MSG_WAITALL))!=sizeof(unsigned short)){
+            if (res!=0) perror("error en recv");
+            close(th->socket);
+            free(th);
+            return NULL;
+        }
         srv_addr_arr_add(th->arr, th->addr.sin_addr.s_addr, port);
         srv_addr_arr_print("después de alta", th->arr);
+        int reply = htonl(0);
+        write(th->socket, &reply, sizeof(int));
+    } else if (opcode == MSG_TYPE_WORKER_RESERVE) {
+        int nworkers_net;
+        if ((res=recv(th->socket, &nworkers_net, sizeof(int), MSG_WAITALL))!=sizeof(int)){
+            if (res!=0) perror("error en recv");
+            close(th->socket);
+            free(th);
+            return NULL;
+        }
+        int nworkers = ntohl(nworkers_net);
+        int *srv = malloc(sizeof(int)*nworkers);
+        if (!srv || srv_addr_arr_alloc(th->arr, nworkers, srv)==-1) {
+            int err = htonl(-1);
+            write(th->socket, &err, sizeof(int));
+            free(srv);
+            close(th->socket);
+            free(th);
+            return NULL;
+        }
+        for (int i=0; i<nworkers; i++) {
+            unsigned int ip; unsigned short port;
+            srv_addr_arr_get(th->arr, srv[i], &ip, &port);
+            write(th->socket, &ip, sizeof(unsigned int));
+            write(th->socket, &port, sizeof(unsigned short));
+        }
+        free(srv);
     }
-    int reply = htonl(0);
-    write(th->socket, &reply, sizeof(int));
     close(th->socket);
     free(th);
     printf("conexión del cliente cerrada\n");

--- a/DATSI/SSDD/map.2025/manager_node/manager.h
+++ b/DATSI/SSDD/map.2025/manager_node/manager.h
@@ -8,6 +8,7 @@
 #define _MANAGER_H        1
 
 #define MSG_TYPE_WORKER_REGISTER 1
+#define MSG_TYPE_WORKER_RESERVE 2
 
 #endif // _MANAGER_H
 


### PR DESCRIPTION
## Summary
- extend manager protocol to handle reservation of multiple workers
- implement reservation logic returning worker IPs and ports
- update client to request workers from manager and dispatch one block per worker

## Testing
- `make` in `client_node`
- `make` in `worker_node`
- `make` in `manager_node`


------
https://chatgpt.com/codex/tasks/task_e_6846dd7a49988323aaed565eb02c2509