### PR TITLE
Implement phase 1 worker registration

### DIFF
--- a/DATSI/SSDD/map.2025/manager_node/manager.c
+++ b/DATSI/SSDD/map.2025/manager_node/manager.c
@@ -1,13 +1,83 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <pthread.h>
 #include "manager.h"
 #include "common.h"
 #include "common_srv.h"
 #include "srv_addr_arr.h"
 
+#define OP_WORKER_REGISTER 1
+
+typedef struct thread_info {
+    int socket;
+    struct sockaddr_in addr;
+    srv_addr_arr *srv_arr;
+} thread_info;
+
+static void *connection_handler(void *arg) {
+    thread_info *th = arg;
+    int res;
+    int opcode;
+    if ((res=recv(th->socket, &opcode, sizeof(opcode), MSG_WAITALL))!=sizeof(opcode)) {
+        if (res!=0) perror("error en recv");
+        close(th->socket);
+        free(th);
+        return NULL;
+    }
+    opcode = ntohl(opcode);
+    if (opcode == OP_WORKER_REGISTER) {
+        unsigned short port;
+        if ((res=recv(th->socket, &port, sizeof(port), MSG_WAITALL))!=sizeof(port)) {
+            if (res!=0) perror("error en recv");
+            close(th->socket);
+            free(th);
+            return NULL;
+        }
+        srv_addr_arr_add(th->srv_arr, th->addr.sin_addr.s_addr, port);
+        srv_addr_arr_print("después de alta", th->srv_arr);
+        int ack=htonl(0);
+        write(th->socket, &ack, sizeof(ack));
+    }
+    close(th->socket);
+    free(th);
+    printf("conexión del cliente cerrada\n");
+    return NULL;
+}
+
 int main(int argc, char *argv[]) {
+    int s, s_conec;
+    unsigned int addr_size;
+    struct sockaddr_in clnt_addr;
     if (argc!=2) {
         fprintf(stderr, "Usage: %s port\n", argv[0]);
         return 1;
     }
+    if ((s=create_socket_srv(atoi(argv[1]), NULL)) < 0) return 1;
+    srv_addr_arr *srv_arr = srv_addr_arr_create();
+    if (!srv_arr) {
+        close(s); return 1;
+    }
+
+    pthread_t thid;
+    pthread_attr_t atrib_th;
+    pthread_attr_init(&atrib_th);
+    pthread_attr_setdetachstate(&atrib_th, PTHREAD_CREATE_DETACHED);
+    while(1) {
+        addr_size=sizeof(clnt_addr);
+        if ((s_conec=accept(s, (struct sockaddr *)&clnt_addr, &addr_size))<0){
+            perror("error en accept");
+            close(s); return 1;
+        }
+        printf("conectado cliente con ip %s y puerto %u (formato red)\n",
+                inet_ntoa(clnt_addr.sin_addr), clnt_addr.sin_port);
+        thread_info *th=malloc(sizeof(thread_info));
+        th->socket = s_conec;
+        th->addr = clnt_addr;
+        th->srv_arr = srv_arr;
+        pthread_create(&thid, &atrib_th, connection_handler, th);
+    }
+    close(s);
     return 0;
 }

--- a/DATSI/SSDD/map.2025/worker_node/worker.c
+++ b/DATSI/SSDD/map.2025/worker_node/worker.c
@@ -1,15 +1,60 @@
 #include <stdio.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <stdlib.h>
 #include "worker.h"
 #include "manager.h"
 #include "common.h"
 #include "common_srv.h"
 #include "common_cln.h"
 
+#define OP_WORKER_REGISTER 1
+
 int main(int argc, char *argv[]) {
+    int s_srv, s_mgr, s_conec;
+    unsigned int addr_size;
+    struct sockaddr_in clnt_addr;
+    unsigned short port;
+
     if (argc!=3) {
         fprintf(stderr, "Usage: %s manager_host manager_port\n", argv[0]);
         return 1;
     }
+    if ((s_srv=create_socket_srv(0, &port)) < 0) return 1;
+    printf("puerto asignado (formato de red) %u\n", port);
+
+    if ((s_mgr=create_socket_cln_by_name(argv[1], argv[2])) < 0) {
+        close(s_srv);
+        return 1;
+    }
+    int op=htonl(OP_WORKER_REGISTER);
+    if (write(s_mgr, &op, sizeof(op)) != sizeof(op)) {
+        perror("error en write");
+        close(s_mgr); close(s_srv); return 1;
+    }
+    if (write(s_mgr, &port, sizeof(port)) != sizeof(port)) {
+        perror("error en write");
+        close(s_mgr); close(s_srv); return 1;
+    }
+    int ack;
+    if (recv(s_mgr, &ack, sizeof(ack), MSG_WAITALL) != sizeof(ack)) {
+        perror("error en recv");
+        close(s_mgr); close(s_srv); return 1;
+    }
+    close(s_mgr);
+
+    while(1) {
+        addr_size=sizeof(clnt_addr);
+        if ((s_conec=accept(s_srv, (struct sockaddr *)&clnt_addr, &addr_size))<0){
+            perror("error en accept");
+            close(s_srv);
+            return 1;
+        }
+        printf("conectado cliente con ip %s y puerto %u (formato red)\n",
+                inet_ntoa(clnt_addr.sin_addr), clnt_addr.sin_port);
+        close(s_conec);
+        printf("conexión del cliente cerrada\n");
+    }
+    close(s_srv);
     return 0;
 }
-


### PR DESCRIPTION
## Summary
- add worker registration protocol
- manager stores worker info and prints status
- worker sends its port to manager

## Testing
- `make -C DATSI/SSDD/map.2025/manager_node clean && make`
- `make -C DATSI/SSDD/map.2025/worker_node clean && make`
- ran manager and two workers locally and observed registration messages

------
https://chatgpt.com/codex/tasks/task_e_68503be1afdc83238518eb1e94ef1b19